### PR TITLE
[Fix] 공지사항 필터링 이슈 

### DIFF
--- a/yappu-world-ios/Source/Data/Auth/DTO/NoticeResponse.swift
+++ b/yappu-world-ios/Source/Data/Auth/DTO/NoticeResponse.swift
@@ -17,7 +17,7 @@ struct NoticeResponse: Codable {
 struct DataClass: Codable {
     let data: [Datum]
     let hasNext: Bool
-    let lastCursor: String
+    let lastCursor: String?
     let limit: Int
 }
 


### PR DESCRIPTION
💡 Issue
- #18 

🌱 Key changes
- (디코딩 에러) DataClass의 lastCursor가 null 일때가 있었습니다

✅ To Reviewers
- 어드민 공지사항 APIdml /admin/v1/notices와 헷갈려 조금 시간이 걸렸습니다
- Swagger에서 select a definition에서 APP API가 따로 있는지 몰라서 '게시판 API'를 찾지 못하고 있었네요...😅
- 그래도 덕분에 네트워크 전반적인 코드와 ViewModel의 메커니즘을 대부분 확인할 수 있었습니다
- 파싱 에러 하나에 너무 늦어져서 죄송합니다..

📸 스크린샷
