### PR TITLE
[Feat] 홈 - 세션 리스트 연동

### DIFF
--- a/yappu-world-ios.xcodeproj/project.pbxproj
+++ b/yappu-world-ios.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "yapp.yappu-world-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -486,7 +486,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "yapp.yappu-world-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/yappu-world-ios.xcodeproj/project.pbxproj
+++ b/yappu-world-ios.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "yapp.yappu-world-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -486,7 +486,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "yapp.yappu-world-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
@@ -45,7 +45,10 @@ struct ActivitySessionSection: View {
             
             scrollIndicator
         }
-        .onAppear(perform: bodyOnAppear)
+        .fixedSize(horizontal: false, vertical: true)
+        .onChange(of: sessionList) { _, _ in
+            sessionListOnChange()
+        }
     }
 }
 
@@ -62,16 +65,17 @@ private extension ActivitySessionSection {
                         .id(index)
                 }
             }
-            .scrollTargetLayout()
             .padding(.top, 10)
             .padding(.bottom, 16)
+            .padding(.leading, scrollIndex == 0 ? 20 : 0)
+            .scrollTargetLayout()
         }
-        .scrollPosition(id: $scrollIndex, anchor: .center)
         .contentMargins(
             scrollIndex == 0 ? .trailing : .horizontal,
             scrollIndex == 0 ? 88 : 44
         )
         .scrollTargetBehavior(.viewAligned)
+        .scrollPosition(id: $scrollIndex, anchor: .center)
     }
     
     @ViewBuilder
@@ -186,7 +190,8 @@ private extension ActivitySessionSection {
 
 // MARK: - Functions
 private extension ActivitySessionSection {
-    func bodyOnAppear() {
+    func sessionListOnChange() {
+        guard sessionList.isEmpty.not() else { return }
         var currentIndex = sessionList.firstIndex(where: { session in
             session.scheduleProgressPhase == .today
         })
@@ -213,7 +218,7 @@ private extension ScheduleEntity.ProgressPhase {
     var title: String {
         switch self {
         case .done: return "완료"
-        case .pending: return "보류"
+        case .pending: return "예정"
         case .today: return "당일"
         case .upcoming: return "임박"
         }
@@ -228,7 +233,6 @@ private extension ScheduleEntity.ProgressPhase {
         scrollIndex: $scrollIndex,
         sessionList: ScheduleEntity.mockList
     )
-    .fixedSize(horizontal: false, vertical: true)
     .padding(.vertical)
     .background(
         LinearGradient(

--- a/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
@@ -14,10 +14,16 @@ struct ActivitySessionSection: View {
     private var scrollIndex: Int?
     
     private let sessionList: [ScheduleEntity]
+    private let allSessionButtonAction: () -> Void
     
-    init(scrollIndex: Binding<Int?>, sessionList: [ScheduleEntity]) {
+    init(
+        scrollIndex: Binding<Int?>,
+        sessionList: [ScheduleEntity],
+        action: @escaping () -> Void
+    ) {
         self._scrollIndex = scrollIndex
         self.sessionList = sessionList
+        self.allSessionButtonAction = action
     }
 
     var body: some View {
@@ -34,10 +40,8 @@ struct ActivitySessionSection: View {
                 
                 Spacer()
                 
-                Button("전체보기") {
-                    
-                }
-                .buttonStyle(.text(style: .normal, size: .small))
+                Button("전체보기", action: allSessionButtonAction)
+                    .buttonStyle(.text(style: .normal, size: .small))
             }
             .padding(.horizontal, 20)
             
@@ -54,7 +58,10 @@ struct ActivitySessionSection: View {
 
 // MARK: - Configure Views
 private extension ActivitySessionSection {
+    @ViewBuilder
     var activitySessionList: some View {
+        let isFirstIndex = (scrollIndex ?? 0) == 0
+        
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: 8) {
                 ForEach(sessionList.indices, id: \.self) { index in
@@ -67,12 +74,12 @@ private extension ActivitySessionSection {
             }
             .padding(.top, 10)
             .padding(.bottom, 16)
-            .padding(.leading, scrollIndex == 0 ? 20 : 0)
+            .padding(.leading, isFirstIndex ? 20 : 0)
             .scrollTargetLayout()
         }
         .contentMargins(
-            scrollIndex == 0 ? .trailing : .horizontal,
-            scrollIndex == 0 ? 88 : 44
+            isFirstIndex ? .trailing : .horizontal,
+            isFirstIndex ? 130 : 65
         )
         .scrollTargetBehavior(.viewAligned)
         .scrollPosition(id: $scrollIndex, anchor: .center)
@@ -131,9 +138,6 @@ private extension ActivitySessionSection {
         .frame(height: 120)
         .containerRelativeFrame(
             .horizontal,
-            count: 1,
-            span: 1,
-            spacing: 8,
             alignment: .leading
         )
         .background(.yapp(.semantic(.background(.normal(.normal)))))
@@ -232,7 +236,9 @@ private extension ScheduleEntity.ProgressPhase {
     ActivitySessionSection(
         scrollIndex: $scrollIndex,
         sessionList: ScheduleEntity.mockList
-    )
+    ) {
+        
+    }
     .padding(.vertical)
     .background(
         LinearGradient(

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
@@ -22,7 +22,9 @@ struct HomeView: View {
                 ActivitySessionSection(
                     scrollIndex: $scrollIndex,
                     sessionList: viewModel.activitySessions
-                )
+                ) {
+                    viewModel.clickAllSessionButton()
+                }
                 .padding(.top, 18)
                 .opacity(Double((180 + scrollOffset) / 100))
                 

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
@@ -38,21 +38,7 @@ struct HomeView: View {
         }
         .coordinateSpace(name: "HomeScrollView")
         .background { background }
-        .refreshable {
-            do {
-                await MainActor.run {
-                    viewModel.resetState()
-                }
-                
-                let _ = try await Task {
-                    try await Task.sleep(for: .seconds(1))
-                    await viewModel.onTask()
-                    return true
-                }.value
-            } catch {
-                print("error", error.localizedDescription)
-            }
-        }
+        .refreshable { await viewModel.scrollViewRefreshable() }
         .yappBottomPopup(isOpen: $viewModel.isSheetOpen) {
             AttendanceAuthSheetView(viewModel: viewModel)
         }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
@@ -8,52 +8,45 @@
 import SwiftUI
 
 struct HomeView: View {
-
+    
     @State
     var viewModel: HomeViewModel
-
+    @State
+    private var scrollIndex: Int?
+    @State
+    private var scrollOffset: CGFloat = 0
+    
     var body: some View {
-        
-        VStack {
-            HStack {
-                Image("yapp_logo")
-                Spacer()
-
-                Button(action: {
-                    viewModel.clickSetting()
-                }, label: {
-                    Image("setting_icon")
-                })
-            }
-            .padding(.horizontal, 20)
-            
-            ScrollView {
-                HomeAttendView(viewModel: viewModel)
+        ScrollView {
+            VStack(spacing: 16) {
+                ActivitySessionSection(
+                    scrollIndex: $scrollIndex,
+                    sessionList: viewModel.activitySessions
+                )
+                .padding(.top, 18)
+                .opacity(Double((180 + scrollOffset) / 100))
                 
-                SessionAttendanceListView(title: "최근 출석 현황", titleFont: .pretendard18(.semibold), histories: viewModel.attendanceHistories, moreButtonAction: viewModel.clickAttendanceHistoryMoreButton)
-                    .padding(.top, 41)
-                
+                scheduleSection
             }
-            .refreshable {
-                do {
-                    await MainActor.run {
-                        viewModel.resetState()
-                    }
-                    
-                    let _ = try await Task {
-                        try await Task.sleep(for: .seconds(1))
-                        try await viewModel.onTask()
-                        return true
-                    }.value
-                } catch {
-                    print("error", error.localizedDescription)
-                }
-            }
+            .trackScrollMetrics(
+                coordinateSpace: "HomeScrollView",
+                offset: $scrollOffset,
+                contentSize: .constant(0)
+            )
         }
-        .background(Color.mainBackgroundNormal.ignoresSafeArea())
-        .task {
+        .coordinateSpace(name: "HomeScrollView")
+        .background { background }
+        .refreshable {
             do {
-                try await viewModel.onTask()
+                await MainActor.run {
+                    viewModel.resetState()
+                }
+                
+                let _ = try await Task {
+                    try await Task.sleep(for: .seconds(1))
+                    await viewModel.onTask()
+                    return true
+                }.value
             } catch {
                 print("error", error.localizedDescription)
             }
@@ -64,11 +57,44 @@ struct HomeView: View {
         .onChange(of: viewModel.isSheetOpen) {
             if viewModel.isSheetOpen.not() { hideKeyboard() }
         }
+        .task { await viewModel.onTask() }
     }
 }
 
 extension HomeView {
-
+    private var background: some View {
+        VStack {
+            LinearGradient(
+                stops: [
+                    Gradient.Stop(color: Color(red: 1, green: 0.68, blue: 0.19), location: 0.00),
+                    Gradient.Stop(color: Color(red: 0.98, green: 0.38, blue: 0.15), location: 1.00),
+                ],
+                startPoint: UnitPoint(x: 0, y: 0.5),
+                endPoint: UnitPoint(x: 1.06, y: 0.5)
+            )
+            .containerRelativeFrame(.vertical) { height, _ in
+                return height / 3 * 2
+            }
+            .ignoresSafeArea()
+            .opacity(Double((180 + scrollOffset) / 100))
+            
+            Color.yapp(.semantic(.background(.normal(.normal))))
+        }
+    }
+    
+    private var scheduleSection: some View {
+        VStack(spacing: 40) {
+            HomeAttendView(viewModel: viewModel)
+            
+            SessionAttendanceListView(title: "최근 출석 현황", titleFont: .pretendard18(.semibold), histories: viewModel.attendanceHistories, moreButtonAction: viewModel.clickAttendanceHistoryMoreButton)
+            
+            Spacer()
+        }
+        .padding(.top, 24)
+        .background(.yapp(.semantic(.background(.normal(.normal)))))
+        .cornerRadius(radius: 12, corners: [.topLeft, .topRight])
+    }
+    
     private func memberBadge(member: Member) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 8)

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -17,6 +17,10 @@ class HomeViewModel {
     private var navigation
     
     @ObservationIgnored
+    @Dependency(Router<TabItem>.self)
+    private var tabRouter
+    
+    @ObservationIgnored
     @Dependency(HomeUseCase.self)
     private var useCase
     
@@ -102,6 +106,10 @@ class HomeViewModel {
     
     func clickBackButton() {
         navigation.pop()
+    }
+    
+    func clickAllSessionButton() {
+        tabRouter.switch(.schedule)
     }
 }
 // MARK: - Private Async Methods

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -66,7 +66,7 @@ class HomeViewModel {
         upcomingSession = nil
     }
     
-    func onTask() async{
+    func onTask() async {
         await loadProfile()
         await loadNoticeList()
         await loadAttendanceHistory()

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -66,6 +66,22 @@ class HomeViewModel {
         upcomingSession = nil
     }
     
+    func scrollViewRefreshable() async {
+        do {
+            await MainActor.run {
+                resetState()
+            }
+            
+            let _ = try await Task {
+                try await Task.sleep(for: .seconds(1))
+                await onTask()
+                return true
+            }.value
+        } catch {
+            print("error", error.localizedDescription)
+        }
+    }
+    
     func onTask() async {
         await loadProfile()
         await loadNoticeList()

--- a/yappu-world-ios/Source/Presentation/Tab/View/YPTabView.swift
+++ b/yappu-world-ios/Source/Presentation/Tab/View/YPTabView.swift
@@ -74,10 +74,8 @@ struct YPTabView: View {
                 }
             }
         }
-        .task {
-            await router.onTask()
-            await onTask()
-        }
+        .task { await router.onTask() }
+        .task { await onTask() }
         .onDisappear { tabRouter.cancelBag() }
         .yappDefaultPopup(isOpen: Binding(get: {
             YPGlobalPopupManager.shared.isPresented


### PR DESCRIPTION
### 💡 Issue
#66 

### 🌱 Key changes
- 홈화면에 세션 리스트 뷰를 연결했습니다.
- 세션 리스트 조회 API를 연동했습니다.
- 앱 버전 1.1로 수정했습니다.

### ✅ To Reviewers
- ~출석현황의 시간이 보이지 않는데.. 컬러 문제는 아닌거 같아서 한번 확인해주세요~
- `HomeViewModel`의 조회 비동기 로직들의 에러 핸들링을 각각의 비동기 함수 블럭에서 실행하는 것으로 바꿨습니다.
하나라도 오류나면 나머지 로직들이 실행이 안되는 문제가 있어서 수정했습니다.
```Swift
func onTask() async {
    await loadProfile()
    await loadNoticeList()
    await loadAttendanceHistory()
    await loadUpcomingSession()
    await loadSessions()
}
```

### 📸 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-06 at 00 03 50](https://github.com/user-attachments/assets/9dbfce55-f965-4a27-b39a-30085540b9f8)
