### PR TITLE
[Feat] 출석 상태에 따른 로직 및 UI

### DIFF
--- a/yappu-world-ios/Source/DesignSystem/Button/YPButtonStyle.swift
+++ b/yappu-world-ios/Source/DesignSystem/Button/YPButtonStyle.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 
-public enum ColorStyle {
+public enum ColorStyle: Equatable {
     case primary
     case border
     case secondary
+    case custom(fg: Color, bg: Color)
 }
 
 public struct YPButtonStyle: ButtonStyle {
@@ -72,6 +73,11 @@ public extension YPButtonStyle {
             return isEnabled
             ? .yapp(.semantic(.primary(.normal)))
             : .yapp(.semantic(.label(.disable)))
+        case let .custom(fg: color, bg: _):
+            switch isEnabled {
+            case true: return color
+            case false: return .gray30
+            }
         default: return .yapp_primary
         }
     }
@@ -85,6 +91,11 @@ public extension YPButtonStyle {
             }
         case .secondary:
             return .yapp(.semantic(.line(.normal)))
+        case let .custom(fg: _, bg: color):
+            switch isEnabled {
+            case true: return color
+            case false: return .gray30
+            }
         default: return .yapp_primary
         }
     }
@@ -93,6 +104,11 @@ public extension YPButtonStyle {
         if colorStyle == .primary {
             switch isEnabled {
             case true: return .yapp_primary
+            case false: return .disabledGray
+            }
+        } else if case let .custom(fg: _, bg: color) = colorStyle {
+            switch isEnabled {
+            case true: return color
             case false: return .disabledGray
             }
         } else {

--- a/yappu-world-ios/Source/DesignSystem/Support/Color/Color+YAPP.swift
+++ b/yappu-world-ios/Source/DesignSystem/Support/Color/Color+YAPP.swift
@@ -49,6 +49,7 @@ public extension Color {
     static let activetyCellBackgroundColor: Color = .init(hex: "#FFF8F5")
     static let certifiedMemberColor: Color = .init(hex: "#FFCB31")
     static let orange99: Color = .init(hex: "#FFF8F5")
+    static let orange95: Color = .init(hex: "#FFEFE9")
     static let coolNeutral50: Color = .init(hex: "#70737C")
     static let common100: Color = .init(hex: "#FFFFFF")
 }

--- a/yappu-world-ios/Source/Presentation/Home/Common/UpcomingSessionAttendanceState.swift
+++ b/yappu-world-ios/Source/Presentation/Home/Common/UpcomingSessionAttendanceState.swift
@@ -7,44 +7,42 @@
 
 import Foundation
 
-enum UpcomingSessionAttendanceState {
-    case Inactive(Date)     // 출석 불가능 + 미출석
-    case Available          // 출석 가능 + 미출석
-    case Attended           // 이미 출석함
-    case NoSession          // 세션 정보 없음
+enum UpcomingSessionAttendanceState: Equatable {
+    case Inactive_Dday         // 출석 불가능 + 미출석 + 당일
+    case Inactive_Yet(String)  // 출석 불가능 + 미출석 + 당일 이후
+    case Available             // 출석 가능 + 미출석
+    case Attended              // 이미 출석함
+    case NoSession             // 세션 정보 없음
     
     var banner: String {
         switch self {
-        case .Inactive:
-            "다가오는 세션을 준비해볼까요?"
-        case .Available, .Attended:
+        case .Inactive_Dday, .Available, .Attended:
             "세션 당일이에요! 활기찬 하루 되세요 :) "
+        case .Inactive_Yet:
+            "다가오는 세션을 준비해볼까요?"
         case .NoSession:
-            ""
-        }
-    }
-    
-    var title: String {
-        switch self {
-        case .Inactive:
-            "오늘은 \(Date().formatted(as: "MM월 dd일"))이에요."
-        case .Available, .Attended:
-            ""
-        case .NoSession:
-            ""
+            "다가오는 세션이 없어요."
         }
     }
     
     var button: String {
         switch self {
-        case .Inactive(let date):
-            "\(date.formatted(as: "MM월 dd일")) 세션예정"
+        case .Inactive_Dday:
+            "20분 전부터 출석이 가능해요"
+        case .Inactive_Yet(let date):
+            "\(date) 세션예정"
         case .Available:
             "출석하기"
         case .Attended:
             "출석완료!"
-        case .NoSession:
-            ""
+        default: ""
+        }
+    }
+    
+    var isDisabled: Bool {
+        switch self {
+        case .Inactive_Dday, .Inactive_Yet: true
+        default: false
         }
     }
 }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
@@ -10,17 +10,19 @@ import SwiftUI
 struct HomeAttendView: View {
     
     var upcomingSession: UpcomingSession?
+    var upcomingState: UpcomingSessionAttendanceState
 
     private var attendanceButtonAction: (() -> Void)?
 
-    init(upcomingSession: UpcomingSession?, attendanceButtonAction: (() -> Void)? = nil) {
+    init(upcomingSession: UpcomingSession?, upcomingState: UpcomingSessionAttendanceState, attendanceButtonAction: (() -> Void)? = nil) {
         self.upcomingSession = upcomingSession
+        self.upcomingState = upcomingState
         self.attendanceButtonAction = attendanceButtonAction
     }
     
     var body: some View {
         VStack(spacing: 12) {
-            NoticeBanner(text: upcomingSession == nil ? "다가오는 세션이 없어요." : "세션 당일이예요! 활기찬 하루 되세요:)")
+            NoticeBanner(text: upcomingState.banner)
             AttendanceCard()
         } // VStack
         .padding(.horizontal, 20)
@@ -46,47 +48,76 @@ private extension HomeAttendView {
     @ViewBuilder
     func AttendanceCard() -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let upcomingSession = upcomingSession {
-                // 세션 제목
-                Text("\(upcomingSession.name)")
-                    .font(.pretendard13(.medium))
-                    .foregroundStyle(.labelGray)
-                
-                // 시간 정보
-                HStack {
-                    HStack(spacing: 4) {
-                        Image("clock")
-                        
-                        if let startTime = upcomingSession.startTime {
-                            Text("\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
-                                .font(.pretendard14(.medium))
-                                .foregroundStyle(.yapp_primary)
-                        }
-                    }
-                    
-                    Spacer()
-                }
-                .padding(.top, 10)
-                
-                if let attendanceButtonAction {
-                    // 출석 버튼
-                    Button(action: {
-                        attendanceButtonAction()
-                    }) {
-                        Text(upcomingSession.canCheckIn ? "20분 전부터 출석이 가능해요" : "출석하기")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.yapp(radius: 8, style: .primary))
-                    .disabled(upcomingSession.canCheckIn)
-                    .padding(.top, 12)
-                }
-            } else {
+            if upcomingState == .NoSession {
                 Text("모든 세션이 종료되었어요.\n기수 활동에 참여해 주셔서 감사합니다 :)")
                     .font(.pretendard12(.medium))
                     .foregroundStyle(.gray60)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
                     .frame(maxWidth: .infinity)
+            } else {
+                if let upcomingSession = upcomingSession {
+                    // 세션 제목
+                    let sessionTitle: String = {
+                        if case .Inactive_Yet = upcomingState {
+                            return "오늘은 \(Date().formatted(as: "MM월 dd일이에요."))"
+                        } else {
+                            return upcomingSession.name
+                        }
+                    }()
+                    
+                    Text(sessionTitle)
+                        .font(.pretendard13(.medium))
+                        .foregroundStyle(.labelGray)
+                    
+                    // 시간 정보
+                    if upcomingState == .Inactive_Dday || upcomingState == .Attended || upcomingState == .Available {
+                        HStack(spacing: 4) {
+                            HStack(spacing: 4) {
+                                Image("clock")
+                                
+                                if let startTime = upcomingSession.startTime, let endTime = upcomingSession.endTime {
+                                    Text(upcomingState == .Attended ? "\(endTime.toTimeFormat(as: "a h시 mm분")) 종료" :  "\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
+                                        .font(.pretendard14(.medium))
+                                        .foregroundStyle(.yapp_primary)
+                                }
+                            }
+                            
+                            Spacer()
+                            
+                            if upcomingState == .Attended {
+                                Text("진행중")
+                                    .font(.pretendard11(.medium))
+                                    .foregroundStyle(.common100)
+                                    .frame(height: 14)
+                                    .padding(.vertical, 2)
+                                    .padding(.horizontal, 8)
+                                    .background(.coolNeutral50)
+                                    .clipRectangle(6)
+                                
+                                if let startTime = upcomingSession.startTime {
+                                    Text("\(startTime.prefix(5))~")
+                                        .font(.pretendard13(.medium))
+                                        .foregroundStyle(.labelGray)
+                                }
+                            }
+                        }
+                        .padding(.top, 10)
+                    }
+                    
+                    if let attendanceButtonAction {
+                        // 출석 버튼
+                        Button(action: {
+                            attendanceButtonAction()
+                        }) {
+                            Text(upcomingState.button)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(upcomingState == .Attended ? .yapp(radius: 8, style: .custom(fg: .yapp(.semantic(.primary(.normal))), bg: .orange95)) : .yapp(radius: 8, style: .primary))
+                        .disabled(upcomingState.isDisabled)
+                        .padding(.top, 12)
+                    }
+                }
             }
         }
         .padding(20)
@@ -99,5 +130,7 @@ private extension HomeAttendView {
 }
 
 #Preview {
-    HomeAttendView(upcomingSession: .dummy())
+    HomeAttendView(upcomingSession: .dummy(), upcomingState: .Attended, attendanceButtonAction: {
+        
+    })
 }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
@@ -9,13 +9,18 @@ import SwiftUI
 
 struct HomeAttendView: View {
     
-    @State
-    var viewModel: HomeViewModel
+    var upcomingSession: UpcomingSession?
+
+    private var attendanceButtonAction: (() -> Void)?
+
+    init(upcomingSession: UpcomingSession?, attendanceButtonAction: (() -> Void)? = nil) {
+        self.upcomingSession = upcomingSession
+        self.attendanceButtonAction = attendanceButtonAction
+    }
     
-    @ViewBuilder
     var body: some View {
         VStack(spacing: 12) {
-            NoticeBanner(text: viewModel.upcomingSession == nil ? "다가오는 세션이 없어요." : "세션 당일이예요! 활기찬 하루 되세요:)")
+            NoticeBanner(text: upcomingSession == nil ? "다가오는 세션이 없어요." : "세션 당일이예요! 활기찬 하루 되세요:)")
             AttendanceCard()
         } // VStack
         .padding(.horizontal, 20)
@@ -41,7 +46,7 @@ private extension HomeAttendView {
     @ViewBuilder
     func AttendanceCard() -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let upcomingSession = viewModel.upcomingSession {
+            if let upcomingSession = upcomingSession {
                 // 세션 제목
                 Text("\(upcomingSession.name)")
                     .font(.pretendard13(.medium))
@@ -63,16 +68,18 @@ private extension HomeAttendView {
                 }
                 .padding(.top, 10)
                 
-                // 출석 버튼
-                Button(action: {
-                    viewModel.clickSheetToggle()
-                }) {
-                    Text(viewModel.isAttendDisabled ? "20분 전부터 출석이 가능해요" : "출석하기")
-                        .frame(maxWidth: .infinity)
+                if let attendanceButtonAction {
+                    // 출석 버튼
+                    Button(action: {
+                        attendanceButtonAction()
+                    }) {
+                        Text(upcomingSession.canCheckIn ? "20분 전부터 출석이 가능해요" : "출석하기")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.yapp(radius: 8, style: .primary))
+                    .disabled(upcomingSession.canCheckIn)
+                    .padding(.top, 12)
                 }
-                .buttonStyle(.yapp(radius: 8, style: .primary))
-                .disabled(viewModel.isAttendDisabled)
-                .padding(.top, 12)
             } else {
                 Text("모든 세션이 종료되었어요.\n기수 활동에 참여해 주셔서 감사합니다 :)")
                     .font(.pretendard12(.medium))
@@ -92,5 +99,5 @@ private extension HomeAttendView {
 }
 
 #Preview {
-    HomeAttendView(viewModel: HomeViewModel())
+    HomeAttendView(upcomingSession: .dummy())
 }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
@@ -28,7 +28,7 @@ struct HomeView: View {
             .padding(.horizontal, 20)
             
             ScrollView {
-                HomeAttendView(viewModel: viewModel)
+                HomeAttendView(upcomingSession: viewModel.upcomingSession, attendanceButtonAction: viewModel.clickSheetToggle)
                 
                 SessionAttendanceListView(title: "최근 출석 현황", titleFont: .pretendard18(.semibold), histories: viewModel.attendanceHistories, moreButtonAction: viewModel.clickAttendanceHistoryMoreButton)
                     .padding(.top, 41)

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeView.swift
@@ -28,7 +28,7 @@ struct HomeView: View {
             .padding(.horizontal, 20)
             
             ScrollView {
-                HomeAttendView(upcomingSession: viewModel.upcomingSession, attendanceButtonAction: viewModel.clickSheetToggle)
+                HomeAttendView(upcomingSession: viewModel.upcomingSession, upcomingState: viewModel.upcomingState, attendanceButtonAction: viewModel.clickSheetToggle)
                 
                 SessionAttendanceListView(title: "최근 출석 현황", titleFont: .pretendard18(.semibold), histories: viewModel.attendanceHistories, moreButtonAction: viewModel.clickAttendanceHistoryMoreButton)
                     .padding(.top, 41)

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -187,6 +187,8 @@ private extension HomeViewModel {
             switch ypError.errorCode {
             case "ATD_1001":
                 otpState = .error("출석코드가 일치하지 않습니다. 다시 확인해주세요")
+            case "USR_0006": // 활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다
+                upcomingState = .NoSession
             default:
                 otpState = .error(ypError.message)
             }

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -32,10 +32,10 @@ class HomeViewModel {
     @Dependency(\.userStorage)
     private var userStorage
     
-    var profile: Profile? = nil
+//    var profile: Profile? = nil
     var upcomingSession: UpcomingSession? = nil
 
-    var noticeList: [NoticeEntity] = [.loadingDummy(), .loadingDummy(), .loadingDummy()]
+//    var noticeList: [NoticeEntity] = [.loadingDummy(), .loadingDummy(), .loadingDummy()]
     
     var attendanceHistories: [ScheduleEntity] = [.dummy(), .dummy(), .dummy()]
     
@@ -47,19 +47,19 @@ class HomeViewModel {
     var isInvalid: Bool = false
     var otpCount: Int = 4
     
-    var isLoading: Bool {
-       profile == nil
-    }
+//    var isLoading: Bool {
+//       profile == nil
+//    }
     
     func resetState() {
-        profile = nil
+//        profile = nil
         upcomingSession = nil
     }
     
     func onTask() async throws {
         do {
-            try await loadProfile()
-            try await loadNoticeList()
+//            try await loadProfile()
+//            try await loadNoticeList()
             try await loadAttendanceHistory()
             try await loadUpcomingSession()
         } catch(let error as YPError) {
@@ -69,8 +69,9 @@ class HomeViewModel {
             case "USR_0006": // 해당 세대의 활동 정보를 가진 유저를 찾을 수 없습니다.
                 upcomingSession = nil
             default:
-                self.profile = .dummy()
-                self.noticeList = []
+                break
+//                self.profile = .dummy()
+//                self.noticeList = []
             }
         }
     }
@@ -111,26 +112,26 @@ class HomeViewModel {
 }
 // MARK: - Private Async Methods
 private extension HomeViewModel {
-    private func loadProfile() async throws {
-        
-        guard profile == nil else { return }
-        
-        let profileResponse = try await useCase.loadProfile()
-        await self.userStorage.save(user: profileResponse.data)
-        await MainActor.run {
-            self.profile = profileResponse.data
-        }
-    }
+//    private func loadProfile() async throws {
+//        
+//        guard profile == nil else { return }
+//        
+//        let profileResponse = try await useCase.loadProfile()
+//        await self.userStorage.save(user: profileResponse.data)
+//        await MainActor.run {
+//            self.profile = profileResponse.data
+//        }
+//    }
     
-    private func loadNoticeList() async throws {
-        let noticeResponse = try await noticeUseCase.loadNotices(model: .init(lastCursorId: nil, limit: 3, noticeType: "ALL"))
-        
-        await MainActor.run {
-            if let notices = noticeResponse?.data {
-                self.noticeList = notices.data.map({ $0.toEntity() })
-            }
-        }
-    }
+//    private func loadNoticeList() async throws {
+//        let noticeResponse = try await noticeUseCase.loadNotices(model: .init(lastCursorId: nil, limit: 3, noticeType: "ALL"))
+//        
+//        await MainActor.run {
+//            if let notices = noticeResponse?.data {
+//                self.noticeList = notices.data.map({ $0.toEntity() })
+//            }
+//        }
+//    }
     
     private func loadUpcomingSession() async throws {
         

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -32,10 +32,7 @@ class HomeViewModel {
     @Dependency(\.userStorage)
     private var userStorage
     
-//    var profile: Profile? = nil
     var upcomingSession: UpcomingSession? = nil
-
-//    var noticeList: [NoticeEntity] = [.loadingDummy(), .loadingDummy(), .loadingDummy()]
     
     var attendanceHistories: [ScheduleEntity] = [.dummy(), .dummy(), .dummy()]
     
@@ -47,20 +44,13 @@ class HomeViewModel {
     var isInvalid: Bool = false
     var otpCount: Int = 4
     
-//    var isLoading: Bool {
-//       profile == nil
-//    }
-    
     func resetState() {
-//        profile = nil
         upcomingSession = nil
         upcomingState = .NoSession
     }
     
     func onTask() async throws {
         do {
-//            try await loadProfile()
-//            try await loadNoticeList()
             try await loadAttendanceHistory()
             try await loadUpcomingSession()
         } catch(let error as YPError) {
@@ -71,8 +61,6 @@ class HomeViewModel {
                 upcomingSession = nil
             default:
                 break
-//                self.profile = .dummy()
-//                self.noticeList = []
             }
             upcomingState = .NoSession
         }
@@ -114,26 +102,6 @@ class HomeViewModel {
 }
 // MARK: - Private Async Methods
 private extension HomeViewModel {
-//    private func loadProfile() async throws {
-//        
-//        guard profile == nil else { return }
-//        
-//        let profileResponse = try await useCase.loadProfile()
-//        await self.userStorage.save(user: profileResponse.data)
-//        await MainActor.run {
-//            self.profile = profileResponse.data
-//        }
-//    }
-    
-//    private func loadNoticeList() async throws {
-//        let noticeResponse = try await noticeUseCase.loadNotices(model: .init(lastCursorId: nil, limit: 3, noticeType: "ALL"))
-//        
-//        await MainActor.run {
-//            if let notices = noticeResponse?.data {
-//                self.noticeList = notices.data.map({ $0.toEntity() })
-//            }
-//        }
-//    }
     
     private func loadUpcomingSession() async {
         do {


### PR DESCRIPTION
### 💡 Issue
- #69 

### 🌱 Key changes
- 5가지 상황에 따른 로직 및 UI 처리
```swift
enum UpcomingSessionAttendanceState: Equatable {
    case Inactive_Dday         // 출석 불가능 시간 + 미출석 상태 + 당일
    case Inactive_Yet(String)  // 출석 불가능 시간 + 미출석 상태 + 당일 이후
    case Available             // 출석 가능 시간 + 미출석 상태
    case Attended              // 이미 출석함
    case NoSession             // 세션 정보 없음
```

### ✅ To Reviewers
- 11e5ee24dea4d461a23a3756a1de4b57144fdc8f : Profile과 NoticeCellList는 더이상 사용하지 않아 삭제해도 될것 같아요
- 9769e5c0144d712dfc9f50fd522e298ae6730a62 : 버튼 스타일의 case .custom(foregroundStyle: Color, backgroundColor: Color)를 추가 했습니다
- fetchAttendance() : OTP 4자리를 입력후 button click에 대한 network 처리 로직에서 성공후, 임박한 세션을 다시 불러옵니다
그래서 임박한 세션에 대한  "USR_0006(활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다)"인 에러 상태도 같이 처리했습니다

```swift
    private func fetchAttendance() async {
        guard let upcomingSession = upcomingSession else { return }
        
        do {
            let _ = try await useCase.fetchAttendance(
                model: .init(sessionId: upcomingSession.sessionId, attendanceCode: otpText) // sessionId 임시
            )
            let upcomingSessionsResponse = try await useCase.loadUpcomingSession()

            await MainActor.run {
                calculateByUpcomingStatus(upcomingSession: upcomingSessionsResponse.data)
                reset() // 닫기
            }
        } catch {
            guard let ypError = error as? YPError else { return }
            switch ypError.errorCode {
            case "ATD_1001":
                otpState = .error("출석코드가 일치하지 않습니다. 다시 확인해주세요")
            case "USR_0006": // 활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다
                upcomingState = .NoSession
            default:
                otpState = .error(ypError.message)
            }
            isInvalid.toggle() // 흔들리는 효과
        }
    }
```

### 📸 스크린샷
