### PR TITLE
[Fix] 오늘의 세션으로 명칭 변경 / 스펠링 틀린거 수정

### DIFF
--- a/yappu-world-ios/Source/Presentation/Schedule/Session/SessionScheduleView.swift
+++ b/yappu-world-ios/Source/Presentation/Schedule/Session/SessionScheduleView.swift
@@ -17,33 +17,32 @@ struct SessionScheduleView: View {
                 
                 HStack(alignment: .lastTextBaseline) {
                     
-                    Text("다음 세션")
+                    Text("오늘의 세션")
                         .font(.pretendard17(.semibold))
                         .foregroundStyle(.yapp(.semantic(.label(.normal))))
                         .padding(.top, 20)
                         
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 8)
-                            .foregroundStyle(.yapp(.semantic(.primary(.normal))))
-                        
-                        if let upcomming = viewModel.upcommingSession {
-                            Text("D\(upcomming.relativeDays ?? 0 < 0 ? "\(String(describing: upcomming.relativeDays))" : "-day")")
+                    if let _ = viewModel.upcomingSession {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 8)
+                                .foregroundStyle(.yapp(.semantic(.primary(.normal))))        
+                            Text("D-day")
                                 .font(.pretendard13(.medium))
                                 .foregroundStyle(.white)
                                 .padding(.vertical, 6)
                                 .padding(.horizontal, 10)
                         }
+                        .fixedSize()
+                        .offset(x: 0, y: -1)
                     }
-                    .fixedSize()
-                    .offset(x: 0, y: -1)
                     
                     Spacer()
                 }
                 .padding(.horizontal, 20)
                 
                 Group {
-                    if let upcomming = viewModel.upcommingSession {
-                        let item = upcomming.toCellData(isToday: false, viewType: .today)
+                    if let upcoming = viewModel.upcomingSession {
+                        let item = upcoming.toCellData(isToday: false, viewType: .today)
                         YPScheduleCell(model: item, isLast: true)
                     } else if viewModel.isInit {
                         Text("오늘은 예정된 세션이 없어요.")

--- a/yappu-world-ios/Source/Presentation/Schedule/Session/SessionScheduleViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Schedule/Session/SessionScheduleViewModel.swift
@@ -18,7 +18,7 @@ class SessionScheduleViewModel {
     var isInit: Bool = false
     
     var sessions: [ScheduleEntity] = []
-    var upcommingSession: ScheduleEntity? = nil
+    var upcomingSession: ScheduleEntity? = nil
     
     init() {
         
@@ -30,7 +30,7 @@ class SessionScheduleViewModel {
             await MainActor.run {
                 isInit = false
                 sessions = []
-                upcommingSession = nil
+                upcomingSession = nil
             }
         }
         
@@ -45,8 +45,8 @@ class SessionScheduleViewModel {
                 await MainActor.run {
                     sessions = data.sessions.map { $0.toEntity() }
                     
-                    if let upcomming = data.sessions.first(where: { $0.id == data.upcomingSessionId ?? "" }) {
-                        upcommingSession = upcomming.toEntity()
+                    if let upcoming = data.sessions.first(where: { $0.id == data.upcomingSessionId ?? "" }), upcoming.relativeDays == 0 {
+                        upcomingSession = upcoming.toEntity()
                     }
                     
                     isInit = true


### PR DESCRIPTION
### 💡 Issue
- #90 

### 🌱 Key changes
- 오늘의 세션으로 명칭 변경 (relativeDays == 0 일경우에만 보여주는걸로 복구)
- 스펠링 틀린거 수정

### ✅ To Reviewers
- 리뷰어에게 특별히 알리고 싶은게 있다면 적어주세요.

### 📸 스크린샷
