### PR TITLE
Feature/#99 session progress state

### DIFF
--- a/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
@@ -91,7 +91,7 @@ private extension ActivitySessionSection {
             phase = .pending
         }
         
-            return VStack(alignment: .leading, spacing: 4) {
+        return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Text(phase.title)
                     .font(.pretendard11(.medium))

--- a/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/ActivitySessionSection.swift
@@ -85,11 +85,13 @@ private extension ActivitySessionSection {
         .scrollPosition(id: $scrollIndex, anchor: .center)
     }
     
-    @ViewBuilder
     func activitySessionListCell(_ item: ScheduleEntity) -> some View {
-        let phase = item.scheduleProgressPhase ?? .pending
+        var phase = item.scheduleProgressPhase ?? .pending
+        if phase == .done && item.relativeDays ?? 0 < 0 {
+            phase = .pending
+        }
         
-        VStack(alignment: .leading, spacing: 4) {
+            return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Text(phase.title)
                     .font(.pretendard11(.medium))


### PR DESCRIPTION
### 💡 Issue
#99 

### 🌱 Key changes
- 세션 진행 상태 변경사항 반영

### ✅ To Reviewers
- 상태가 `done` 인 경우에도 `relativeDays`가 0 미만일 경우 `pending`으로 나오도록 수정하였습니다.
```Swift
func activitySessionListCell(_ item: ScheduleEntity) -> some View {
  var phase = item.scheduleProgressPhase ?? .pending
  if phase == .done && item.relativeDays ?? 0 < 0 {
      phase = .pending
  }
...
```

### 📸 스크린샷
