### PR TITLE
[Feat] 출석 완료 상태에 따라 버튼 노출 메세지 변경

### DIFF
--- a/yappu-world-ios/Source/Presentation/Home/Common/UpcomingSessionAttendanceState.swift
+++ b/yappu-world-ios/Source/Presentation/Home/Common/UpcomingSessionAttendanceState.swift
@@ -8,40 +8,51 @@
 import Foundation
 
 enum UpcomingSessionAttendanceState: Equatable {
-    case Inactive_Dday         // 출석 불가능 + 미출석 + 당일
-    case Inactive_Yet(String)  // 출석 불가능 + 미출석 + 당일 이후
-    case Available             // 출석 가능 + 미출석
-    case Attended              // 이미 출석함
-    case NoSession             // 세션 정보 없음
+    case INACTIVE_DAY          // 출석 불가능 + 미출석 + 당일
+    case INACTIVE_YET(String)  // 출석 불가능 + 미출석 + 당일 이후
+    case AVAILABLE             // 출석 가능 + 미출석
+    case ATTENDED              // 출석
+    case LATE                  // 지각
+    case ABSENT                // 결석
+    case EARLY_LEAVE           // 조퇴
+    case EXCUSED               // 공결
+    case NOSESSION             // 세션 정보 없음
     
     var banner: String {
         switch self {
-        case .Inactive_Dday, .Available, .Attended:
+        case .INACTIVE_DAY, .AVAILABLE, .ATTENDED, .LATE, .ABSENT, .EARLY_LEAVE, .EXCUSED:
             "세션 당일이에요! 활기찬 하루 되세요 :) "
-        case .Inactive_Yet:
+        case .INACTIVE_YET:
             "다가오는 세션을 준비해볼까요?"
-        case .NoSession:
+        case .NOSESSION:
             "다가오는 세션이 없어요."
         }
     }
     
     var button: String {
         switch self {
-        case .Inactive_Dday:
+        case .INACTIVE_DAY:
             "20분 전부터 출석이 가능해요"
-        case .Inactive_Yet(let date):
+        case .INACTIVE_YET(let date):
             "\(date) 세션예정"
-        case .Available:
+        case .AVAILABLE:
             "출석하기"
-        case .Attended:
-            "출석완료!"
-        default: ""
+        case .ATTENDED:
+            "출석 완료!"
+        case .LATE, .ABSENT:
+            "다음엔 조금 더 일찍 오기!"
+        case .EARLY_LEAVE:
+            "다음엔 끝까지 함께 해요~"
+        case .EXCUSED:
+            "다음 세션엔 함께 해요!"
+        case .NOSESSION:
+            ""
         }
     }
     
     var isDisabled: Bool {
         switch self {
-        case .Inactive_Dday, .Inactive_Yet: true
+        case .INACTIVE_DAY, .INACTIVE_YET: true
         default: false
         }
     }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
@@ -48,7 +48,7 @@ private extension HomeAttendView {
     @ViewBuilder
     func AttendanceCard() -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if upcomingState == .NoSession {
+            if upcomingState == .NOSESSION {
                 Text("모든 세션이 종료되었어요.\n기수 활동에 참여해 주셔서 감사합니다 :)")
                     .font(.pretendard12(.medium))
                     .foregroundStyle(.gray60)
@@ -59,7 +59,7 @@ private extension HomeAttendView {
                 if let upcomingSession = upcomingSession {
                     // 세션 제목
                     let sessionTitle: String = {
-                        if case .Inactive_Yet = upcomingState {
+                        if case .INACTIVE_YET = upcomingState {
                             return "오늘은 \(Date().formatted(as: "MM월 dd일이에요."))"
                         } else {
                             return upcomingSession.name
@@ -71,13 +71,13 @@ private extension HomeAttendView {
                         .foregroundStyle(.labelGray)
                     
                     // 시간 정보
-                    if upcomingState == .Inactive_Dday || upcomingState == .Attended || upcomingState == .Available {
+                    if upcomingState == .INACTIVE_DAY || upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED || upcomingState == .AVAILABLE {
                         HStack(spacing: 4) {
                             HStack(spacing: 4) {
                                 Image("clock")
                                 
                                 if let startTime = upcomingSession.startTime, let endTime = upcomingSession.endTime {
-                                    Text(upcomingState == .Attended ? "\(endTime.toTimeFormat(as: "a h시 mm분")) 종료" :  "\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
+                                    Text(upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED ? "\(endTime.toTimeFormat(as: "a h시 mm분")) 종료" :  "\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
                                         .font(.pretendard14(.medium))
                                         .foregroundStyle(.yapp_primary)
                                 }
@@ -85,7 +85,7 @@ private extension HomeAttendView {
                             
                             Spacer()
                             
-                            if upcomingState == .Attended {
+                            if upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED {
                                 Text("진행중")
                                     .font(.pretendard11(.medium))
                                     .foregroundStyle(.common100)
@@ -108,13 +108,13 @@ private extension HomeAttendView {
                     if let attendanceButtonAction {
                         // 출석 버튼
                         Button(action: {
-                            if upcomingState == .Attended { return }
+                            if upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED { return }
                             attendanceButtonAction()
                         }) {
                             Text(upcomingState.button)
                                 .frame(maxWidth: .infinity)
                         }
-                        .buttonStyle(upcomingState == .Attended ? .yapp(radius: 8, style: .custom(fg: .yapp(.semantic(.primary(.normal))), bg: .orange95)) : .yapp(radius: 8, style: .primary))
+                        .buttonStyle(upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED ? .yapp(radius: 8, style: .custom(fg: .yapp(.semantic(.primary(.normal))), bg: .orange95)) : .yapp(radius: 8, style: .primary))
                         .disabled(upcomingState.isDisabled)
                         .padding(.top, 12)
                     }
@@ -131,7 +131,7 @@ private extension HomeAttendView {
 }
 
 #Preview {
-    HomeAttendView(upcomingSession: .dummy(), upcomingState: .Attended, attendanceButtonAction: {
+    HomeAttendView(upcomingSession: .dummy(), upcomingState: .ATTENDED, attendanceButtonAction: {
         
     })
 }

--- a/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
+++ b/yappu-world-ios/Source/Presentation/Home/View/HomeAttendView.swift
@@ -11,6 +11,7 @@ struct HomeAttendView: View {
     
     var upcomingSession: UpcomingSession?
     var upcomingState: UpcomingSessionAttendanceState
+    var isAtteded: Bool
 
     private var attendanceButtonAction: (() -> Void)?
 
@@ -18,6 +19,7 @@ struct HomeAttendView: View {
         self.upcomingSession = upcomingSession
         self.upcomingState = upcomingState
         self.attendanceButtonAction = attendanceButtonAction
+        self.isAtteded = upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED
     }
     
     var body: some View {
@@ -71,13 +73,13 @@ private extension HomeAttendView {
                         .foregroundStyle(.labelGray)
                     
                     // 시간 정보
-                    if upcomingState == .INACTIVE_DAY || upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED || upcomingState == .AVAILABLE {
+                    if upcomingState == .INACTIVE_DAY || isAtteded || upcomingState == .AVAILABLE {
                         HStack(spacing: 4) {
                             HStack(spacing: 4) {
                                 Image("clock")
                                 
                                 if let startTime = upcomingSession.startTime, let endTime = upcomingSession.endTime {
-                                    Text(upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED ? "\(endTime.toTimeFormat(as: "a h시 mm분")) 종료" :  "\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
+                                    Text(isAtteded ? "\(endTime.toTimeFormat(as: "a h시 mm분")) 종료" :  "\(startTime.toTimeFormat(as: "a h시 mm분")) 오픈")
                                         .font(.pretendard14(.medium))
                                         .foregroundStyle(.yapp_primary)
                                 }
@@ -85,7 +87,7 @@ private extension HomeAttendView {
                             
                             Spacer()
                             
-                            if upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED {
+                            if isAtteded {
                                 Text("진행중")
                                     .font(.pretendard11(.medium))
                                     .foregroundStyle(.common100)
@@ -108,13 +110,13 @@ private extension HomeAttendView {
                     if let attendanceButtonAction {
                         // 출석 버튼
                         Button(action: {
-                            if upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED { return }
+                            if isAtteded { return }
                             attendanceButtonAction()
                         }) {
                             Text(upcomingState.button)
                                 .frame(maxWidth: .infinity)
                         }
-                        .buttonStyle(upcomingState == .ATTENDED || upcomingState == .LATE || upcomingState == .ABSENT || upcomingState == .EARLY_LEAVE || upcomingState == .EXCUSED ? .yapp(radius: 8, style: .custom(fg: .yapp(.semantic(.primary(.normal))), bg: .orange95)) : .yapp(radius: 8, style: .primary))
+                        .buttonStyle(isAtteded ? .yapp(radius: 8, style: .custom(fg: .yapp(.semantic(.primary(.normal))), bg: .orange95)) : .yapp(radius: 8, style: .primary))
                         .disabled(upcomingState.isDisabled)
                         .padding(.top, 12)
                     }

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -44,7 +44,7 @@ class HomeViewModel {
     
     var attendanceHistories: [ScheduleEntity] = [.dummy(), .dummy(), .dummy()]
     
-    var upcomingState: UpcomingSessionAttendanceState = .NoSession
+    var upcomingState: UpcomingSessionAttendanceState = .NOSESSION
     var activitySessions: [ScheduleEntity] = ScheduleEntity.mockList
       
     var isSheetOpen: Bool = false
@@ -55,7 +55,7 @@ class HomeViewModel {
     
     func resetState() {
         upcomingSession = nil
-        upcomingState = .NoSession
+        upcomingState = .NOSESSION
     }
     
     func scrollViewRefreshable() async {
@@ -129,7 +129,7 @@ private extension HomeViewModel {
                 calculateByUpcomingStatus(upcomingSession: upcomingSessionsResponse.data)
             }
         } catch(let error as YPError) {
-            upcomingState = .NoSession
+            upcomingState = .NOSESSION
             errorHandling(error)
         } catch {
             print(error)
@@ -140,18 +140,26 @@ private extension HomeViewModel {
         self.upcomingSession = upcomingSession
         
         if upcomingSession.status == "출석" {
-            upcomingState = .Attended
+            upcomingState = .ATTENDED
+        } else if upcomingSession.status == "지각" {
+            upcomingState = .LATE
+        } else if upcomingSession.status == "결석" {
+            upcomingState = .ABSENT
+        } else if upcomingSession.status == "조퇴" {
+            upcomingState = .EARLY_LEAVE
+        } else if upcomingSession.status == "공결" {
+            upcomingState = .EXCUSED
         } else if upcomingSession.canCheckIn {
             // 출석 가능한 시간인 경우
-            upcomingState = .Available
+            upcomingState = .AVAILABLE
         } else {
             // 출석 가능한 시간은 아니지만, 오늘 날짜인 경우
             if upcomingSession.relativeDays == 0 && upcomingSession.status == nil {
-                upcomingState = .Inactive_Dday
+                upcomingState = .INACTIVE_DAY
             } else {
                 let startDate = upcomingSession.startDate.components(separatedBy: "-")
                 let month = startDate[1], day = startDate[2]
-                upcomingState = .Inactive_Yet("\(month)월 \(day)일")
+                upcomingState = .INACTIVE_YET("\(month)월 \(day)일")
             }
          }
     }
@@ -191,7 +199,7 @@ private extension HomeViewModel {
             case "ATD_1001":
                 otpState = .error("출석코드가 일치하지 않습니다. 다시 확인해주세요")
             case "USR_0006": // 활성화 된 기수가 없어서 임박한 세션이 존재하지 않습니다
-                upcomingState = .NoSession
+                upcomingState = .NOSESSION
             default:
                 otpState = .error(ypError.message)
             }

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -46,7 +46,7 @@ class HomeViewModel {
     
     var upcomingState: UpcomingSessionAttendanceState = .NOSESSION
     var activitySessions: [ScheduleEntity] = ScheduleEntity.mockList
-      
+    
     var isSheetOpen: Bool = false
     var otpText: String = ""
     var otpState: InputState = .typing

--- a/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -136,32 +136,61 @@ private extension HomeViewModel {
         }
     }
     
+    // 1) 상태 문자열을 표현하는 RawValue enum 정의
+    enum SessionStatus: String {
+        case attended    = "출석"   // ATTENDED
+        case late        = "지각"   // LATE
+        case absent      = "결석"   // ABSENT
+        case earlyLeave  = "조퇴"   // EARLY_LEAVE
+        case excused     = "공결"   // EXCUSED
+    }
+
+    // 2) 상태에 따른 upcomingState 값 변경
     private func calculateByUpcomingStatus(upcomingSession: UpcomingSession) {
         self.upcomingSession = upcomingSession
-        
-        if upcomingSession.status == "출석" {
-            upcomingState = .ATTENDED
-        } else if upcomingSession.status == "지각" {
-            upcomingState = .LATE
-        } else if upcomingSession.status == "결석" {
-            upcomingState = .ABSENT
-        } else if upcomingSession.status == "조퇴" {
-            upcomingState = .EARLY_LEAVE
-        } else if upcomingSession.status == "공결" {
-            upcomingState = .EXCUSED
-        } else if upcomingSession.canCheckIn {
-            // 출석 가능한 시간인 경우
-            upcomingState = .AVAILABLE
-        } else {
-            // 출석 가능한 시간은 아니지만, 오늘 날짜인 경우
-            if upcomingSession.relativeDays == 0 && upcomingSession.status == nil {
-                upcomingState = .INACTIVE_DAY
-            } else {
-                let startDate = upcomingSession.startDate.components(separatedBy: "-")
-                let month = startDate[1], day = startDate[2]
-                upcomingState = .INACTIVE_YET("\(month)월 \(day)일")
+
+        // 2-1) status 문자열을 enum으로 파싱
+        if
+            let statusString = upcomingSession.status,
+            let sessionStatus = SessionStatus(rawValue: statusString)
+        {
+            switch sessionStatus {
+            case .attended:
+                upcomingState = .ATTENDED
+            case .late:
+                upcomingState = .LATE
+            case .absent:
+                upcomingState = .ABSENT
+            case .earlyLeave:
+                upcomingState = .EARLY_LEAVE
+            case .excused:
+                upcomingState = .EXCUSED
             }
-         }
+            return
+        }
+
+        // 2-2) 출석 가능 시간인 경우
+        if upcomingSession.canCheckIn {
+            upcomingState = .AVAILABLE
+            return
+        }
+
+        // 2-3) 오늘 날짜지만 아직 상태가 없는 경우
+        if upcomingSession.relativeDays == 0 && upcomingSession.status == nil {
+            upcomingState = .INACTIVE_DAY
+            return
+        }
+
+        // 2-4) 그 외: startDate에서 월/일을 뽑아서 INACTIVE_YET
+        let parts = upcomingSession.startDate.split(separator: "-")
+        if parts.count >= 3 {
+            let month = parts[1]
+            let day   = parts[2]
+            upcomingState = .INACTIVE_YET("\(month)월 \(day)일")
+        } else {
+            // fallback
+            upcomingState = .INACTIVE_YET("")
+        }
     }
 
     private func loadSessions() async {


### PR DESCRIPTION
### 💡 Issue
- 생성한 이슈 제목과 링크를 달아주세요.
#110 

### 🌱 Key changes
- 출석, 지각, 조퇴, 결석, 공결 에 대한 임박한 세션 버튼 메시지 변경

### ✅ To Reviewers
- 기획에 따른 ViewModel을 조금더 간략화 해야한다고 생각하는데, 아이디어나 조언을 해줄 수 있나요?
```swift
    private func calculateByUpcomingStatus(upcomingSession: UpcomingSession) {
        self.upcomingSession = upcomingSession
        
        if upcomingSession.status == "출석" {
            upcomingState = .ATTENDED
        } else if upcomingSession.status == "지각" {
            upcomingState = .LATE
        } else if upcomingSession.status == "결석" {
            upcomingState = .ABSENT
        } else if upcomingSession.status == "조퇴" {
            upcomingState = .EARLY_LEAVE
        } else if upcomingSession.status == "공결" {
            upcomingState = .EXCUSED
        } else if upcomingSession.canCheckIn {
            // 출석 가능한 시간인 경우
            upcomingState = .AVAILABLE
        } else {
            // 출석 가능한 시간은 아니지만, 오늘 날짜인 경우
            if upcomingSession.relativeDays == 0 && upcomingSession.status == nil {
                upcomingState = .INACTIVE_DAY
            } else {
                let startDate = upcomingSession.startDate.components(separatedBy: "-")
                let month = startDate[1], day = startDate[2]
                upcomingState = .INACTIVE_YET("\(month)월 \(day)일")
            }
         }
    }

```

### 📸 스크린샷
