### PR TITLE
[Feat] 최근 출석 현황 세션 이름 표기

### DIFF
--- a/yappu-world-ios/Source/Data/Auth/DTO/Response/AttendanceHistoriesResponse.swift
+++ b/yappu-world-ios/Source/Data/Auth/DTO/Response/AttendanceHistoriesResponse.swift
@@ -19,15 +19,15 @@ struct AttendanceHistoryResponse: Decodable {
 }
 
 extension AttendanceHistoryResponse {
-    func toEntity() -> ScheduleEntity {
+    func toEntity(time: String? = nil, endTime: String? = nil) -> ScheduleEntity {
         .init(
             id: sessionId,
             name: name,
             place: nil,
             date: checkedInAt,
             endDate: nil,
-            time: nil,
-            endTime: nil,
+            time: time,
+            endTime: endTime,
             scheduleType: nil,
             sessionType: nil,
             scheduleProgressPhase: nil,

--- a/yappu-world-ios/Source/DesignSystem/Cell/YPScheduleCell.swift
+++ b/yappu-world-ios/Source/DesignSystem/Cell/YPScheduleCell.swift
@@ -127,7 +127,21 @@ extension YPScheduleCell {
     var flatTypeView: some View {
         VStack(spacing: 0) {
             HStack(alignment: .firstTextBaseline) {
-                Text(convertDay())
+                let name = model.item.name
+                let time = model.item.time?.convertDateFormat(
+                    from: .sessionTime,
+                    to: .scheduleCellTime
+                ) ?? ""
+                let endTime = model.item.endTime?.convertDateFormat(
+                    from: .sessionTime,
+                    to: .scheduleCellTime
+                ) ?? ""
+                let checkedAt = model.item.date?.convertDateFormat(
+                    from: .history,
+                    to: .scheduleCellTime
+                ) ?? ""
+                
+                Text("\(name) / \(time)-\(endTime) / \(checkedAt)")
                     .font(.pretendard13(.regular))
                     .foregroundStyle(.yapp(.semantic(.label(.alternative))))
                     .padding(.trailing, 8)

--- a/yappu-world-ios/Source/Domain/Entity/SchedulesEntity.swift
+++ b/yappu-world-ios/Source/Domain/Entity/SchedulesEntity.swift
@@ -61,7 +61,7 @@ extension ScheduleEntity {
             id: "c07aa77e-1b30-11f0-add0-0242ac140002",
             name: "가짜 세션1",
             place: "아몰랑",
-            date: "2025-04-18",
+            date: "2025-04-17T13:18:17",
             endDate: "2025-04-18",
             time: "13:30:00",
             endTime: "17:00:00",

--- a/yappu-world-ios/Source/Presentation/MyPage/AttendanceList/AttendanceListViewModel.swift
+++ b/yappu-world-ios/Source/Presentation/MyPage/AttendanceList/AttendanceListViewModel.swift
@@ -18,6 +18,9 @@ class AttendanceListViewModel {
     @ObservationIgnored
     @Dependency(AttendanceUseCase.self)
     private var useCase
+    @ObservationIgnored
+    @Dependency(SessionUseCase.self)
+    private var sessionUseCase
     
     var isInit: Bool = true
     
@@ -32,7 +35,8 @@ class AttendanceListViewModel {
         do {
             let statistic = try await useCase.loadStatistics()
             let histories = try await useCase.loadHistory()
-            
+            let sessions = try await sessionUseCase.loadSessions()?.data.sessions
+                .map { $0.toEntity() }
             
             await MainActor.run {
                 if statistic?.isSuccess ?? false {
@@ -40,7 +44,13 @@ class AttendanceListViewModel {
                 }
                 
                 if histories?.isSuccess ?? false {
-                    self.histories = histories?.data.histories.map { $0.toEntity() } ?? []
+                    self.histories = histories?.data.histories.map { history in
+                        let session = sessions?.first { $0.id == history.sessionId }
+                        return history.toEntity(
+                            time: session?.time,
+                            endTime: session?.endTime
+                        )
+                    } ?? []
                 }
                 
                 isInit = false

--- a/yappu-world-ios/Source/Util/DateStyle.swift
+++ b/yappu-world-ios/Source/Util/DateStyle.swift
@@ -12,6 +12,8 @@ enum DateStyle: String, CaseIterable {
     case sessionTime = "HH:mm:ss"
     case activitySessionDate = "yyyy. MM. dd (E)"
     case activitySessionTime = "a h시 m분"
+    case scheduleCellTime = "HH:mm"
+    case history = "yyyy-MM-dd'T'HH:mm:ss"
     
     static var cachedFormatter: [DateStyle: DateFormatter] {
         var formatters = [DateStyle: DateFormatter]()


### PR DESCRIPTION
### 💡 Issue
- #117 
- 최근 출석 현황 세션 이름 표기

### 🌱 Key changes
- `AttendanceHistoryResponse` `toEntity()`메소드에 세션 시간 파라미터 추가
- `AttendanceListViewModel`에 세션 목록 조회 로직 추가

### ✅ To Reviewers
- 리뷰어에게 특별히 알리고 싶은게 있다면 적어주세요.
- 현재 출석내역 조회는 세션 시간이 나오지 않아, 이를 매핑시키기 위해 세션 목록 조회를 한번 호출합니다. 조금은 비효율적이라 생각이 들긴 하는데... 의견 있으시면 말씀주시면 감사하겠습니다.
- 26기 계정이 없어서.. 테스트 가능하시면 해주시면 감사하겠습니다.

### 📸 스크린샷
<img width="400" alt="스크린샷 2025-07-02 20 44 00" src="https://github.com/user-attachments/assets/b4ab50ca-c756-4974-b2b5-272fdade9eb0" />


close #117 